### PR TITLE
Fix Docker CI: add setup-buildx-action

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary

The `cache-to: type=gha` backend requires the `docker-container` buildx driver. The default `docker` driver on GitHub-hosted runners does not support it, causing the workflow to fail immediately with:

```
ERROR: Cache export is not supported for the docker driver.
```

Fix: add `docker/setup-buildx-action@v3` before the build step, which creates a builder using the `docker-container` driver.

## Test plan

- [ ] Docker workflow completes successfully and pushes `ghcr.io/davidgz1/howdirty:latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)