### PR TITLE
v0.6.0: Parameter documentation in report and Docker README improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ The CLI Docker image is published at `ghcr.io/davidgz1/howdirty:latest` and buil
 
 Key files:
 - `Dockerfile` — `rocker/r-ver:4.2.0` base, `renv::restore()` from `renv.lock`, `R CMD INSTALL`
-- `docker/entrypoint.sh` — CLI with `--dataset`, `--peak-areas`, `--annotation`, `--get-template` flags
+- `docker/entrypoint.sh` — CLI with `--dataset`, `--peak-areas`, `--annotation`, `--ref-thresholds`, `--output-dir`, `--interactive-plots`, `--user-names`, `--notes`, `--keep-missing-contaminants`, `--top-n`, `--multiply-dilution-factor`, `--get-template` flags
 - `docker/run_report.R` — calls `generate_howdirty_report()` or `get_annotation_template()`
 
 **Windows PowerShell usage** (add Docker to PATH first):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,8 @@ plot_*() functions          # ggplot2-based; wrapped with ggplotly() when
       │
       ▼
 write.xlsx()                # exports all summary tables to a multi-sheet Excel file
+                            # first sheet is always input_params (HowDirty version +
+                            # all Rmd params), followed by the summary result tables
 ```
 
 ### Key design decisions

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: HowDirty
 Type: Package
 Title: Evaluate How Dirty are LC-MS Samples
-Version: 0.5.0
+Version: 0.6.0
 Authors@R: person("David", "Gomez-Zepeda",
     email = "davidgz.science@gmail.com",
     role = c("aut", "cre"))

--- a/README.md
+++ b/README.md
@@ -79,31 +79,92 @@ b)
 
 If you don't have R installed, you can run HowDirty using Docker — no R setup required.
 
+### Step 0 — Install Docker and add it to PATH
+
+1. Download and install **Docker Desktop** from https://www.docker.com/products/docker-desktop
+2. Launch Docker Desktop and wait until it shows "Docker is running"
+3. Add the Docker CLI to your PATH so you can run `docker` commands from any terminal:
+
+**Windows (PowerShell) — current session only:**
+```powershell
+$env:PATH += ";C:\Program Files\Docker\Docker\resources\bin"
+```
+
+**Windows (PowerShell) — permanent (all future sessions):**
+```powershell
+[System.Environment]::SetEnvironmentVariable(
+    "PATH",
+    $env:PATH + ";C:\Program Files\Docker\Docker\resources\bin",
+    "User"
+)
+```
+Then restart PowerShell for the change to take effect.
+
+**macOS / Linux:** Docker Desktop adds the CLI to PATH automatically during installation. If `docker` is not found, restart your terminal or log out and back in.
+
+Verify the installation:
 ```bash
-# Step 1 — generate a blank annotation template from your Skyline export
+docker --version
+```
+
+### Step 1 — Pull the image
+
+```bash
+docker pull ghcr.io/davidgz1/howdirty:latest
+```
+
+### Step 2 — Generate an annotation template
+
+Navigate to your data folder first, then run:
+
+```bash
+# Linux / macOS
 docker run --rm -v $(pwd):/data ghcr.io/davidgz1/howdirty \
   --get-template --peak-areas /data/PeakAreas_Contaminants.csv
-# → writes samples_annotation_template.csv to your working directory
+```
 
-# Step 2 — fill in the annotation file, then generate the report
+```powershell
+# Windows (PowerShell)
+docker run --rm -v "${PWD}:/data" ghcr.io/davidgz1/howdirty `
+  --get-template --peak-areas /data/PeakAreas_Contaminants.csv
+```
+
+This writes `samples_annotation_template.csv` to your current directory. Fill it in before the next step.
+
+### Step 3 — Generate the report
+
+```bash
+# Linux / macOS
 docker run --rm -v $(pwd):/data ghcr.io/davidgz1/howdirty \
   --dataset MyExperiment \
   --peak-areas /data/PeakAreas_Contaminants.csv \
   --annotation /data/samples_annotation.csv
-# → writes MyExperiment_HowDirtyReport.html and .xlsx to ./results/
 ```
 
-To use a reference threshold file:
-
-```bash
-docker run --rm -v $(pwd):/data ghcr.io/davidgz1/howdirty \
-  --dataset MyExperiment \
-  --peak-areas /data/PeakAreas_Contaminants.csv \
-  --annotation /data/samples_annotation.csv \
-  --ref-thresholds /data/reference_report.xlsx
+```powershell
+# Windows (PowerShell)
+docker run --rm -v "${PWD}:/data" ghcr.io/davidgz1/howdirty `
+  --dataset MyExperiment `
+  --peak-areas /data/PeakAreas_Contaminants.csv `
+  --annotation /data/samples_annotation.csv
 ```
 
-Run `docker run --rm ghcr.io/davidgz1/howdirty --help` for the full list of options.
+This writes `MyExperiment_HowDirtyReport.html` and `.xlsx` to a `results/` subfolder in your data directory.
+
+### Optional flags
+
+| Flag | Description | Default |
+|---|---|---|
+| `--ref-thresholds FILE` | Reference HowDirty Excel output for threshold comparison | none |
+| `--output-dir DIR` | Output directory inside the container | `/data/results` |
+| `--interactive-plots` | Enable interactive plotly plots | static |
+| `--user-names TEXT` | Analyst name(s) shown in the report header | — |
+| `--notes TEXT` | Notes shown in the report header | — |
+| `--keep-missing-contaminants` | Keep contaminants not detected in any sample | removed |
+| `--top-n INT` | Number of top contaminant groups shown in plots | 10 |
+| `--multiply-dilution-factor` | Multiply abundance by the DilutionFactor column | off |
+
+Run `docker run --rm ghcr.io/davidgz1/howdirty --help` for the full reference.
 
 ## License
 

--- a/inst/rmarkdown/templates/howdirty/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/howdirty/skeleton/skeleton.Rmd
@@ -58,9 +58,12 @@ params:
 }
 </style>
 
+
 # Report information
 
-## Data set information
+## Project information
+
+**Objective:** Evaluate the risk of possible contamination with polymers and small molecules in the samples from the data set.
 
 **Data set:** `r params$DataSet`
 
@@ -70,7 +73,19 @@ params:
 
 **Notes:** `r params$Notes`
 
-**Objective:** Evaluate the risk of possible contamination with polymers and small molecules in the samples from the data set.
+## Input 
+
+**PeakAreasContaminants**: `r params$PeakAreasContaminantsFile`
+
+**Annotation**: `r params$AnnotationFile`
+
+**Reference thresholds**: `r params$RefThresholdsFile`
+
+**Dilution factor multiplier**: `r params$MultiplyDilutionFactor`
+
+**Remove missing contaminants**: `r params$RemoveMissingContaminants`
+
+**Top n contaminant groups shown**: `r params$nTopContaminantGroups`
 
 ## HowDirty evaluation of LC-MS results
 
@@ -78,7 +93,7 @@ This report was generated using *HowDirty*. This is meant to help you evaluating
 
 **Code author:** David Gomez-Zepeda (HI-TRON)
 
-**Version:** 0.04
+**Version:** 0.5.1
 
 ```{r setup, include=FALSE, warning=FALSE}
 #General parameters for knitr
@@ -139,7 +154,7 @@ print_plot_or_plotly <- function(input, height_plotly = 450, width_plotly = 1000
 
 ## Data analysis
 
-* Raw data was imported into Skyline (MacLean *et al.*, 2010) to extract the features corresponding to possible contaminants (ToDo: add references)
+* Raw data was imported into Skyline (MacLean *et al.*, 2010) to extract the features corresponding to possible contaminants
 * For this purpose, the Molecular Contaminant List template was used (Rardin, 2018)
 * The feature area of extracted ion chromatograms was processed using *HowDirty* to generate this report (Gomez-Zepeda *et al.*, 2023)
 
@@ -457,7 +472,12 @@ if(params$PlotsInteractive == TRUE){
 * Result tables are exported in folder `r filedir_report`.
 
 ```{r echo=FALSE, warning=FALSE}
+input_params <- data.frame(parameter = c( "HowDirty version",
+                                          names(unlist(params))), 
+                           value = c(as.character(packageVersion("HowDirty")),
+                                     unlist(params, use.names = FALSE)))
 res_list<- list(
+  input_params = input_params,
   risk_summ_sampleset = risk_summ_sampleset,
   conta_summ_sampleset = conta_summ_sampleset,
   conta_summ_sample = conta_summ_sample,

--- a/tests/test_report_20260530a.Rmd
+++ b/tests/test_report_20260530a.Rmd
@@ -22,19 +22,19 @@ params:
     input: text
   PeakAreasContaminantsFile:
     label: "PeakAreaContaminants report from Skyline"  # PeaKAreas_Contaminants report (directory/name) resulting from Skyline
-    value: "data/PeakAreas_Contaminants_2021-231.csv"
+    value: "PeakAreas_Contaminants_2021-231.csv"
     input: text 
   AnnotationFile:
     label: "Sample annotation file"  # Samples Annotation directory/name
-    value: "data/samples_annotation_template.csv"
+    value: "samples_annotation_2021-231.csv"
     input: text 
   RefThresholdsFile:
     label: "Reference threshold file (or FALSE if not available)" # file directory/name or FALSE
-    value:  "data/reference_E480_report_contaminants_20230716_1138.xlsx"
+    value:  reference_E480_report_contaminants_20230716_1138.xlsx
     input: text
   OutputDirectory:
     label: "Directory where the report and the results are exported"
-    value: "results"
+    value: results
   RemoveMissingContaminants:
     label: "Remove contaminants that were not identified in any sample"
     value: TRUE
@@ -60,7 +60,9 @@ params:
 
 # Report information
 
-## Data set information
+## Project information
+
+**Objective:** Evaluate the risk of possible contamination with polymers and small molecules in the samples from the data set.
 
 **Data set:** `r params$DataSet`
 
@@ -70,7 +72,19 @@ params:
 
 **Notes:** `r params$Notes`
 
-**Objective:** Evaluate the risk of possible contamination with polymers and small molecules in the samples from the data set.
+## Input 
+
+**PeakAreasContaminants**: `r params$PeakAreasContaminantsFile`
+
+**Annotation**: `r params$AnnotationFile`
+
+**Reference thresholds**: `r params$RefThresholdsFile`
+
+**Dilution factor multiplier**: `r params$MultiplyDilutionFactor`
+
+**Remove missing contaminants**: `r params$RemoveMissingContaminants`
+
+**Top n contaminant groups shown**: `r params$nTopContaminantGroups`
 
 ## HowDirty evaluation of LC-MS results
 
@@ -104,6 +118,7 @@ if(any(!filecheck)){
 ```
 
 
+
 ```{r initialize, message=FALSE, include=FALSE}
 #Install required packages
 ##Test whether all required packages, install packages needed and install if needed
@@ -120,6 +135,7 @@ today_date <- gsub(patt ="-", rep="",paste0(gsub(patt ="-", rep="", Sys.Date()),
 filedir_report <- file.path(params$OutputDirectory,
                             paste0(params$DataSet, "_report_contaminants_", today_date, ".xlsx"))
 filedir_sessioninfo <- gsub(filedir_report, patt = ".xlsx", rep = "_RSessionInfo.txt", filedir_report)
+
 if(!dir.exists(params$OutputDirectory)) dir.create(params$OutputDirectory)
 # report-specific functions
 print_plot_or_plotly <- function(input, height_plotly = 450, width_plotly = 1000, interactive = params$PlotsInteractive){
@@ -273,7 +289,7 @@ plot_pie_risk_summ_sampleset
 
 * Statistical difference was assessed by a Wilcoxon signed-rank test
 
-```{r plot_conta_summ_condition_risk, warning=TRUE, fig.width=4, fig.height=2.5}
+```{r plot_conta_summ_condition_risk, warning=FALSE, fig.width=4, fig.height=2.5}
 plot_conta_summ_condition_risk <-
   plot_condition_risk_total_boxplot(conta_summ_sample,
                                     compare_means = (n_distinct(conta_summ_sample$Condition) > 1), # only if at least 2 conditions
@@ -457,7 +473,12 @@ if(params$PlotsInteractive == TRUE){
 * Result tables are exported in folder `r filedir_report`.
 
 ```{r echo=FALSE, warning=FALSE}
+input_params <- data.frame(parameter = c( "HowDirty version",
+                                          names(unlist(params))), 
+                            value = c(as.character(packageVersion("HowDirty")),
+                                                   unlist(params, use.names = FALSE)))
 res_list<- list(
+  input_params = input_params,
   risk_summ_sampleset = risk_summ_sampleset,
   conta_summ_sampleset = conta_summ_sampleset,
   conta_summ_sample = conta_summ_sample,
@@ -471,6 +492,7 @@ res_list<- list(
 write.xlsx(res_list,
            file = filedir_report)
 writeLines(capture.output(sessionInfo()), filedir_sessioninfo)
+
 ```
 
 ## References - please cite:


### PR DESCRIPTION
## Summary

- Report and xlsx now document all parameters used: new 'Input' section in the HTML header, and an `input_params` sheet prepended to the Excel output (HowDirty version + all Rmd params)
- Expanded README Docker section: install instructions, per-session vs permanent PATH setup for Windows, dual Linux/macOS + PowerShell examples, and a full options table
- CLAUDE.md updated to reflect all Docker CLI flags and the new xlsx sheet structure
- Version bump to 0.6.0

## Test plan

- [x] Knit a report and confirm the 'Input' section shows the correct parameter values
- [x] Open the xlsx and confirm `input_params` is the first sheet with correct entries
- [x] CI passes on Windows and Ubuntu

🤖 Generated with [Claude Code](https://claude.com/claude-code)