### PR TITLE
v0.6.1: Dynamic version in report template

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: HowDirty
 Type: Package
 Title: Evaluate How Dirty are LC-MS Samples
-Version: 0.6.0
+Version: 0.6.1
 Authors@R: person("David", "Gomez-Zepeda",
     email = "davidgz.science@gmail.com",
     role = c("aut", "cre"))

--- a/inst/rmarkdown/templates/howdirty/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/howdirty/skeleton/skeleton.Rmd
@@ -91,9 +91,9 @@ params:
 
 This report was generated using *HowDirty*. This is meant to help you evaluating *How Dirty* are your samples (or system) in LC-MS analyses. The possible contaminants reported hereby could impact the quality of the results (e.g. contaminant IDs and reproducibility) and, in extreme cases, even damage the column or instruments. The raw data are previously analyzed using Skyline to extract LC-MS peaks possibly corresponding to contaminants. Then, a Risk level is assigned to each contaminant by comparing against the reference threshold (see Procedures for details). Finally, the Risk is similarly assessed at the Sample and whole Sample Set levels. These are indicative of the level of possible contamination.
 
-**Code author:** David Gomez-Zepeda (HI-TRON)
+**Code author:** David Gomez-Zepeda (HI-TRON Mainz, a Helmholtz-Institute of the DKFZ)
 
-**Version:** 0.5.1
+**Version:** `r as.character(packageVersion("HowDirty"))`
 
 ```{r setup, include=FALSE, warning=FALSE}
 #General parameters for knitr


### PR DESCRIPTION
## Summary

- Report version now reads dynamically from `packageVersion("HowDirty")` instead of being hardcoded
- Updated institution name to full form (HI-TRON Mainz, a Helmholtz-Institute of the DKFZ)
- Version bump to 0.6.1

## Test plan

- [ ] Knit a report and confirm the version shown matches the installed package version
- [ ] CI passes on Windows and Ubuntu

🤖 Generated with [Claude Code](https://claude.com/claude-code)